### PR TITLE
Add `serializer` to the `attributes` property

### DIFF
--- a/lib/loadable_config.rb
+++ b/lib/loadable_config.rb
@@ -36,9 +36,9 @@ class LoadableConfig
       define_singleton_method(attr) { instance.send(attr) }
     end
 
-    def attributes(*attrs, type: :string, optional: false)
+    def attributes(*attrs, type: :string, optional: false, serializer: nil)
       attrs.each do |attr|
-        attribute(attr, type: type, optional: optional)
+        attribute(attr, type: type, optional: optional, serializer: serializer)
       end
     end
 

--- a/lib/loadable_config/version.rb
+++ b/lib/loadable_config/version.rb
@@ -1,3 +1,3 @@
 class LoadableConfig
-  VERSION = '0.3.4'
+  VERSION = '0.4.4'
 end

--- a/spec/loadable_config_spec.rb
+++ b/spec/loadable_config_spec.rb
@@ -86,7 +86,26 @@ RSpec.describe LoadableConfig do
     end
 
     it 'reads an attribute' do
+      expect(config_class.text1).to eq('Foo')
       expect(config_class.text2).to eq('Bar')
+    end
+
+    context 'with optional arguments' do
+      let(:config_data) do
+        {
+          'text1' => "--- Foo\n...\n",
+          'text2' => "--- Bar\n...\n",
+        }
+      end
+
+      letblk(:attributes) do
+        attributes :text1, :text2, type: :string, serializer: YAML
+      end
+
+      it 'reads an attribute' do
+        expect(config_class.text1).to eq('Foo')
+        expect(config_class.text2).to eq('Bar')
+      end
     end
   end
 


### PR DESCRIPTION
This simply allows one to write:
`attributes :value1, :value2, serializer: MySerializer`

There's unfortunately some overlap with regards to testing with the standard `attribute` property. I couldn't immediately come up with a solution to this, so I took a route that's hopefully only a little ugly.