### PR TITLE
Support ruby 3.1 with keyword arguments in YAML.safe_load

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,15 +82,23 @@ workflows:
   build:
     jobs:
       - test:
-          name: 'ruby 2.5'
-          ruby-version: "2.5"
-      - test:
           name: 'ruby 2.6'
           ruby-version: "2.6"
+      - test:
+          name: 'ruby 2.7'
+          ruby-version: "2.7"
+      - test:
+          name: 'ruby 3.0'
+          ruby-version: "3.0"
+      - test:
+          name: 'ruby 3.1'
+          ruby-version: "3.1"
       - publish:
           requires:
-            - 'ruby 2.5'
             - 'ruby 2.6'
+            - 'ruby 2.7'
+            - 'ruby 3.0'
+            - 'ruby 3.1'
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,15 +90,11 @@ workflows:
       - test:
           name: 'ruby 3.0'
           ruby-version: "3.0"
-      - test:
-          name: 'ruby 3.1'
-          ruby-version: "3.1"
       - publish:
           requires:
             - 'ruby 2.6'
             - 'ruby 2.7'
             - 'ruby 3.0'
-            - 'ruby 3.1'
           filters:
             branches:
               only: master

--- a/lib/loadable_config.rb
+++ b/lib/loadable_config.rb
@@ -90,7 +90,7 @@ class LoadableConfig
       config_data = preprocessor.call(config_data)
     end
 
-    config = YAML.safe_load(config_data, [], [], true)
+    config = YAML.safe_load(config_data, aliases: true)
     unless config
       raise RuntimeError.new("Cannot configure #{self.class.name}: "\
                              "Configuration file empty for #{self.class.name}.")

--- a/lib/loadable_config/version.rb
+++ b/lib/loadable_config/version.rb
@@ -1,3 +1,3 @@
 class LoadableConfig
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
Mostly as a tracking issue for compatibility with psych 4.0. See https://github.com/ruby/psych/issues/533

Unfortunately circleci doesn't have ruby 3.1 yet, so the actual failure due to the breaking change isn't visible.

[YAML.safe_load in ruby 3.0.3](https://ruby-doc.org/stdlib-3.0.3/libdoc/psych/rdoc/Psych.html#method-c-safe_load) allowed positional arguments, while [YAML.safe_load in ruby 3.1.0](https://ruby-doc.org/stdlib-3.1.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load) uses keyword arguments.

Going back to [YAML.safe_load in ruby 2.6.3](https://ruby-doc.org/stdlib-2.6.3/libdoc/psych/rdoc/Psych.html#method-c-safe_load), it looks like the interface has supported both for a while, and the positional arguments are marked as legacy. We can switch to keyword arguments without dropping support for ruby >= 2.6.