### PR TITLE
Support programmatic overlays for loadableconfig classes

### DIFF
--- a/lib/loadable_config.rb
+++ b/lib/loadable_config.rb
@@ -103,6 +103,11 @@ class LoadableConfig
       end
     end
 
+    if (overlay_function = LoadableConfig._configuration.overlay_function)
+      overlay_data = overlay_function.call(self.class)
+      config = _deep_merge(config, overlay_data) if overlay_data
+    end
+
     unless config
       raise RuntimeError.new("Configuration file missing config for #{self.class.name}.")
     end
@@ -141,5 +146,15 @@ class LoadableConfig
       'required'             => self.class._attributes.reject(&:optional).map(&:name),
       'additionalProperties' => false,
     )
+  end
+
+  def _deep_merge(a_hash, b_hash)
+    a_hash.merge(b_hash) do |_key, a_val, b_val|
+      if a_val.is_a?(Hash) && b_val.is_a?(Hash)
+        _deep_merge(a_val, b_val)
+      else
+        b_val
+      end
+    end
   end
 end

--- a/lib/loadable_config/options.rb
+++ b/lib/loadable_config/options.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LoadableConfig::Options
-  attr_reader :config_path_prefix, :environment_key, :preprocessor
+  attr_reader :config_path_prefix, :environment_key, :preprocessor, :overlay_function
 
   def initialize
     # Prefix for configuration file paths. Must be a valid directory, for
@@ -18,6 +18,11 @@ class LoadableConfig::Options
     # If set, uses the provided block to preprocess the configuration file
     # before YAML parsing.
     @preprocessor        = nil
+
+    # If set, calls the provided block with the configuration class after
+    # parsing to obtain a configuration overlay. If a value is returned, it is
+    # deep_merged into the application.
+    @overlay_function    = nil
   end
 
   def config_path_prefix=(val)
@@ -34,5 +39,9 @@ class LoadableConfig::Options
 
   def preprocess(&block)
     @preprocessor = block
+  end
+
+  def overlay(&block)
+    @overlay_function = block
   end
 end

--- a/lib/loadable_config/version.rb
+++ b/lib/loadable_config/version.rb
@@ -1,3 +1,3 @@
 class LoadableConfig
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/spec/loadable_config_spec.rb
+++ b/spec/loadable_config_spec.rb
@@ -389,6 +389,28 @@ RSpec.describe LoadableConfig do
     end
   end
 
+  context 'with a overlay' do
+    let(:config_data) do
+      { 'text' => 'before' }
+    end
+
+    before(:each) do
+      LoadableConfig.configure! do |config|
+        config.overlay do |klazz|
+          { 'text' => "overlaid #{klazz.name}" }
+        end
+      end
+    end
+
+    after(:each) do
+      LoadableConfig.send(:_reinitialize_configuration!)
+    end
+
+    it 'can overlay an attribute' do
+      expect(config_class.text).to eq("overlaid #{config_class.name}")
+    end
+  end
+
   context 'with no config_file set' do
     let(:config_class) do
       Class.new(LoadableConfig) do


### PR DESCRIPTION
A defined overlay block is called during the load of a LoadableConfig with that LoadableConfig class as an argument, and if it returns a value, that hash is merged with the loaded configuration.